### PR TITLE
Update regex to properly match JSON punctuation.

### DIFF
--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/formater/JsonFormater.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/formater/JsonFormater.kt
@@ -17,7 +17,7 @@ internal fun formatJson(json: ByteArray): AnnotatedString = buildAnnotatedString
         val prettyJson = jsonSerializer.encodeToString(JsonElement.serializer(), jsonElement)
 
         // Regex to match JSON parts: strings, numbers, punctuation
-        val regex = Regex("""("(\\.|[^"\\])*"|\d+|[{}\\[\\]:,]|\n|\s+)""")
+        val regex = Regex("""("(\\.|[^"\\])*"|\d+|[{}\[\]:,]|\n|\s+)""")
 
         var isKey = true // Track if the current string is a key
 


### PR DESCRIPTION
Original:
![image](https://github.com/user-attachments/assets/c7ad3ac8-bc9d-450b-9c67-c944aeafa54a)

After the partch:
![image](https://github.com/user-attachments/assets/9a599d69-a150-41ba-8fb2-63de2231f3a2)
