### PR TITLE
Make Res class public

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -110,6 +110,8 @@ sqldelight {
 }
 
 compose.resources {
+    publicResClass = true
+    generateResClass = always
     packageOfResClass = "ro.cosminmihu.ktor.monitor.ui.resources"
 }
 


### PR DESCRIPTION
Making the generated `Res` class public to allow it to be bundled into the XCFramework.

#20 