### PR TITLE
Refactor DetailScreen to use TopAppBar and simplify tab layout

### DIFF
--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/Dimens.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/Dimens.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.unit.dp
 internal object Dimens {
     val Small = 8.dp
     val Medium = 16.dp
-    val MediumLarge = 20.dp
     val Large = 24.dp
     val ExtraLarge = 32.dp
     val ExtraExtraLarge = 48.dp

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/Dimens.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/Dimens.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.dp
 internal object Dimens {
     val Small = 8.dp
     val Medium = 16.dp
+    val MediumLarge = 20.dp
     val Large = 24.dp
     val ExtraLarge = 32.dp
     val ExtraExtraLarge = 48.dp

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -85,7 +85,7 @@ internal fun DetailScreen(
                                         style = MaterialTheme.typography.titleMedium.copy(
                                             fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
                                         ),
-                                        modifier = Modifier.padding(vertical = Dimens.Medium + 4.dp)
+                                        modifier = Modifier.padding(vertical = Dimens.MediumLarge)
                                     )
                                 }
                             }

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -87,7 +87,6 @@ internal fun DetailScreen(
                                         style = MaterialTheme.typography.titleMedium.copy(
                                             fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
                                         ),
-                                        modifier = Modifier.padding(vertical = Dimens.MediumLarge)
                                     )
                                 }
                             }

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -29,7 +28,6 @@ import org.jetbrains.compose.resources.stringResource
 import ro.cosminmihu.ktor.monitor.ui.Dimens
 import ro.cosminmihu.ktor.monitor.ui.resources.Res
 import ro.cosminmihu.ktor.monitor.ui.resources.ktor_back
-import ro.cosminmihu.ktor.monitor.ui.resources.ktor_more
 import ro.cosminmihu.ktor.monitor.ui.resources.ktor_request
 import ro.cosminmihu.ktor.monitor.ui.resources.ktor_response
 import ro.cosminmihu.ktor.monitor.ui.resources.ktor_summary
@@ -97,13 +95,13 @@ internal fun DetailScreen(
                         }
                     },
                     actions = {
-                        IconButton(onClick = {}, enabled = false) {
-                            Icon(
-                                imageVector = Icons.Filled.MoreVert,
-                                contentDescription = stringResource(Res.string.ktor_more),
-                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-                            )
-                        }
+//                        IconButton(onClick = {}, enabled = false) {
+//                            Icon(
+//                                imageVector = Icons.Filled.MoreVert,
+//                                contentDescription = stringResource(Res.string.ktor_more),
+//                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+//                            )
+//                        }
                     },
                     scrollBehavior = scrollBehavior
                 )

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -1,22 +1,16 @@
 package ro.cosminmihu.ktor.monitor.ui.detail
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -24,11 +18,12 @@ import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import ro.cosminmihu.ktor.monitor.ui.Dimens
@@ -54,108 +49,76 @@ internal fun DetailScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState { PAGE_COUNT }
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
     Scaffold(
         modifier = modifier,
-    ) {
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                            contentDescription = stringResource(Res.string.ktor_back),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                title = {
+                    val host = uiState.call?.request?.host
+                    if (!host.isNullOrBlank()) {
+                        Text(text = host)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = {}, enabled = false) {
+                        Icon(
+                            imageVector = Icons.Filled.MoreVert,
+                            contentDescription = stringResource(Res.string.ktor_more),
+                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        }
+    ) { paddingValues ->
         Column(
-            modifier = Modifier.padding(it).fillMaxWidth()
+            modifier = Modifier.padding(paddingValues).fillMaxWidth()
         ) {
 
             if (uiState.call == null || uiState.summary == null) {
                 return@Column
             }
 
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.height(TopAppBarDefaults.TopAppBarExpandedHeight)
+            PrimaryTabRow(
+                selectedTabIndex = pagerState.currentPage,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
             ) {
-                Column(
-                    modifier = Modifier.fillMaxHeight().width(IntrinsicSize.Max)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(start = Dimens.Small, top = Dimens.Small),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        IconButton(onClick = onBack) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
-                                contentDescription = stringResource(Res.string.ktor_back),
-                                tint = MaterialTheme.colorScheme.primary
-                            )
+                val tabs = listOf(
+                    Res.string.ktor_summary,
+                    Res.string.ktor_request,
+                    Res.string.ktor_response
+                )
+
+                tabs.forEachIndexed { index, stringRes ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch { pagerState.animateScrollToPage(index) }
                         }
-                    }
-
-                    HorizontalDivider(modifier = Modifier.fillMaxWidth())
-                }
-
-                PrimaryTabRow(
-                    selectedTabIndex = pagerState.currentPage,
-                    modifier = Modifier.align(Alignment.Bottom).weight(1f)
-                ) {
-                    Tab(
-                        selected = pagerState.currentPage == PAGE_INDEX_SUMMARY,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(PAGE_INDEX_SUMMARY)
-                            }
-                        },
                     ) {
                         Text(
-                            text = stringResource(Res.string.ktor_summary),
-                            modifier = Modifier.padding(vertical = Dimens.Medium)
-                        )
-                    }
-                    Tab(
-                        selected = pagerState.currentPage == PAGE_INDEX_REQUEST,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(PAGE_INDEX_REQUEST)
-                            }
-                        },
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.ktor_request),
-                            modifier = Modifier.padding(vertical = Dimens.Medium)
-                        )
-                    }
-                    Tab(
-                        selected = pagerState.currentPage == PAGE_INDEX_RESPONSE,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(PAGE_INDEX_RESPONSE)
-                            }
-                        },
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.ktor_response),
-                            modifier = Modifier.padding(vertical = Dimens.Medium)
+                            text = stringResource(stringRes),
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
+                            ),
+                            modifier = Modifier.padding(vertical = Dimens.Small)
                         )
                     }
                 }
-
-//                Column(
-//                    modifier = Modifier.fillMaxHeight().width(IntrinsicSize.Max)
-//                ) {
-//                    Box(
-//                        modifier = Modifier
-//                            .weight(1f)
-//                            .padding(start = Dimens.Small, top = Dimens.Small),
-//                        contentAlignment = Alignment.Center
-//                    ) {
-//                        IconButton(onClick = { /* TODO */ }) {
-//                            Icon(
-//                                imageVector = Icons.Default.MoreVert,
-//                                contentDescription = stringResource(Res.string.ktor_more),
-//                                tint = MaterialTheme.colorScheme.primary
-//                            )
-//                        }
-//                    }
-//
-//                    HorizontalDivider(modifier = Modifier.fillMaxWidth())
-//                }
             }
 
             HorizontalPager(

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -18,11 +18,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import ro.cosminmihu.ktor.monitor.ui.Dimens
@@ -66,8 +66,6 @@ internal fun DetailScreen(
                         PrimaryTabRow(
                             selectedTabIndex = pagerState.currentPage,
                             divider = {},
-                            modifier = Modifier
-                                .fillMaxWidth()
                         ) {
                             val tabs = listOf(
                                 Res.string.ktor_summary,
@@ -87,6 +85,7 @@ internal fun DetailScreen(
                                         style = MaterialTheme.typography.titleMedium.copy(
                                             fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
                                         ),
+                                        modifier = Modifier.padding(vertical = Dimens.Medium + 4.dp)
                                     )
                                 }
                             }

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -88,7 +88,7 @@ internal fun DetailScreen(
                                         style = MaterialTheme.typography.titleMedium.copy(
                                             fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
                                         ),
-                                        modifier = Modifier.padding(vertical = Dimens.Small)
+                                        modifier = Modifier.padding(vertical = Dimens.MediumLarge)
                                     )
                                 }
                             }

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,33 +54,61 @@ internal fun DetailScreen(
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
-                            contentDescription = stringResource(Res.string.ktor_back),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                },
-                title = {
-                    val host = uiState.call?.request?.host
-                    if (!host.isNullOrBlank()) {
-                        Text(text = host)
-                    }
-                },
-                actions = {
-                    IconButton(onClick = {}, enabled = false) {
-                        Icon(
-                            imageVector = Icons.Filled.MoreVert,
-                            contentDescription = stringResource(Res.string.ktor_more),
-                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-                        )
-                    }
-                },
-                scrollBehavior = scrollBehavior
-            )
+            Column {
+                TopAppBar(
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                                contentDescription = stringResource(Res.string.ktor_back),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    },
+                    title = {
+                        PrimaryTabRow(
+                            selectedTabIndex = pagerState.currentPage,
+                            divider = {},
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        ) {
+                            val tabs = listOf(
+                                Res.string.ktor_summary,
+                                Res.string.ktor_request,
+                                Res.string.ktor_response
+                            )
+
+                            tabs.forEachIndexed { index, stringRes ->
+                                Tab(
+                                    selected = pagerState.currentPage == index,
+                                    onClick = {
+                                        coroutineScope.launch { pagerState.animateScrollToPage(index) }
+                                    }
+                                ) {
+                                    Text(
+                                        text = stringResource(stringRes),
+                                        style = MaterialTheme.typography.titleMedium.copy(
+                                            fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
+                                        ),
+                                        modifier = Modifier.padding(vertical = Dimens.Small)
+                                    )
+                                }
+                            }
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = {}, enabled = false) {
+                            Icon(
+                                imageVector = Icons.Filled.MoreVert,
+                                contentDescription = stringResource(Res.string.ktor_more),
+                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior
+                )
+                HorizontalDivider()
+            }
         }
     ) { paddingValues ->
         Column(
@@ -89,36 +117,6 @@ internal fun DetailScreen(
 
             if (uiState.call == null || uiState.summary == null) {
                 return@Column
-            }
-
-            PrimaryTabRow(
-                selectedTabIndex = pagerState.currentPage,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-            ) {
-                val tabs = listOf(
-                    Res.string.ktor_summary,
-                    Res.string.ktor_request,
-                    Res.string.ktor_response
-                )
-
-                tabs.forEachIndexed { index, stringRes ->
-                    Tab(
-                        selected = pagerState.currentPage == index,
-                        onClick = {
-                            coroutineScope.launch { pagerState.animateScrollToPage(index) }
-                        }
-                    ) {
-                        Text(
-                            text = stringResource(stringRes),
-                            style = MaterialTheme.typography.titleMedium.copy(
-                                fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Normal
-                            ),
-                            modifier = Modifier.padding(vertical = Dimens.Small)
-                        )
-                    }
-                }
             }
 
             HorizontalPager(

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/detail/DetailScreen.kt
@@ -47,7 +47,6 @@ internal fun DetailScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState { PAGE_COUNT }
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
     Scaffold(
         modifier = modifier,
@@ -103,7 +102,6 @@ internal fun DetailScreen(
 //                            )
 //                        }
                     },
-                    scrollBehavior = scrollBehavior
                 )
                 HorizontalDivider()
             }

--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/list/ListScreen.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/ui/list/ListScreen.kt
@@ -1,6 +1,10 @@
 package ro.cosminmihu.ktor.monitor.ui.list
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -57,71 +61,77 @@ internal fun ListScreen(
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(Res.string.ktor_library_name),
-                        fontWeight = FontWeight.Bold,
-                    )
-                },
-                navigationIcon = {
-                    Image(
-                        imageVector = vectorResource(Res.drawable.ktor_ic_launcher),
-                        contentDescription = stringResource(Res.string.ktor_library_name),
-                        modifier = Modifier.size(Dimens.ExtraExtraLarge)
-                    )
-                },
-                actions = {
-                    if (uiState.isEmpty && !showSearchBar) return@TopAppBar
+            Column {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(Res.string.ktor_library_name),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    },
+                    navigationIcon = {
+                        Image(
+                            imageVector = vectorResource(Res.drawable.ktor_ic_launcher),
+                            contentDescription = stringResource(Res.string.ktor_library_name),
+                            modifier = Modifier.size(Dimens.ExtraExtraLarge)
+                        )
+                    },
+                    actions = {
+                        if (uiState.isEmpty && !showSearchBar) return@TopAppBar
 
-                    IconButton(
-                        onClick = {
-                            showSearchBar = !showSearchBar
-                            if (!showSearchBar) {
-                                clearSearchQuery()
+                        IconButton(
+                            onClick = {
+                                showSearchBar = !showSearchBar
+                                if (!showSearchBar) {
+                                    clearSearchQuery()
+                                }
                             }
+                        ) {
+                            Icon(
+                                imageVector = when (showSearchBar) {
+                                    true -> Icons.Filled.SearchOff
+                                    else -> Icons.Filled.Search
+                                },
+                                contentDescription = stringResource(Res.string.ktor_filter),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
                         }
-                    ) {
-                        Icon(
-                            imageVector = when (showSearchBar) {
-                                true -> Icons.Filled.SearchOff
-                                else -> Icons.Filled.Search
-                            },
-                            contentDescription = stringResource(Res.string.ktor_filter),
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                    IconButton(
-                        onClick = {
-                            deleteCalls()
-                            clearSearchQuery()
-                            showSearchBar = false
+                        IconButton(
+                            onClick = {
+                                deleteCalls()
+                                clearSearchQuery()
+                                showSearchBar = false
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(Res.string.ktor_clean),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
                         }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = stringResource(Res.string.ktor_clean),
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                }
-            )
-        }
-    ) {
-        Column(modifier = Modifier.padding(it).fillMaxWidth()) {
+                    },
+                )
 
-            if (uiState.showNotification) {
+                AnimatedVisibility(visible = showSearchBar) {
+                    SearchField(
+                        onSearch = setSearchQuery,
+                        onClear = clearSearchQuery
+                    )
+                }
+
+                HorizontalDivider()
+            }
+        }
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues).fillMaxWidth()) {
+
+            AnimatedVisibility(
+                visible = uiState.showNotification,
+                enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+                exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
+            ) {
                 NotificationPermissionBanner()
             }
-
-            AnimatedVisibility(visible = showSearchBar) {
-                SearchField(
-                    onSearch = setSearchQuery,
-                    onClear = clearSearchQuery
-                )
-            }
-
-            HorizontalDivider()
 
             when {
                 uiState.isLoading -> {


### PR DESCRIPTION
This commit refactors the `DetailScreen` composable.

Key changes:
- Replaced the custom top bar implementation with `TopAppBar`.
- The `TopAppBar` now displays the request host as the title and includes a back button and a disabled more options button.
- Simplified the tab creation logic by iterating over a list of string resources.
- Adjusted tab text styling and padding.
- Removed unused imports and commented-out code.

<img src="https://github.com/user-attachments/assets/7932ce2b-baa6-495b-90a2-de7250de23d1" width="360" alt="DetailScreen Refactor" />