### PR TITLE
Wrap MainRoute in SelectionContainer to enable text selection

### DIFF
--- a/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/KtorMonitor.kt
+++ b/library/src/commonMain/kotlin/ro/cosminmihu/ktor/monitor/KtorMonitor.kt
@@ -1,5 +1,6 @@
 package ro.cosminmihu.ktor.monitor
 
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import ro.cosminmihu.ktor.monitor.ui.main.MainRoute
@@ -12,8 +13,10 @@ public fun KtorMonitor(
     modifier: Modifier = Modifier,
     useKtorMonitorTheme: Boolean = true,
 ) {
-    MainRoute(
-        modifier = modifier,
-        useLibraryTheme = useKtorMonitorTheme,
-    )
+    SelectionContainer {
+        MainRoute(
+            modifier = modifier,
+            useLibraryTheme = useKtorMonitorTheme,
+        )
+    }
 }


### PR DESCRIPTION
This update enhances UX by wrapping the MainRoute composable in a SelectionContainer, allowing users to select and copy text within the UI. This is particularly useful for copying details, URLs, or content from lists.

This addresses one of the suggestions on this issue #28 

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/514385a8-8119-4c0e-ad6b-86115f953588" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/296c7670-0e8e-4d0c-ad2d-de4218dd9b68" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/91263218-51c0-4998-893e-fe5a031e82d0" width="200"/></td>
  </tr>
</table>
