### PR TITLE
Remove material-icons-extended dependency

### DIFF
--- a/core/library/build.gradle.kts
+++ b/core/library/build.gradle.kts
@@ -173,7 +173,6 @@ kotlin {
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)
-            implementation(libs.compose.material.icons.extended)
             implementation(libs.compose.material3.adaptive.navigation.suite)
             implementation(libs.compose.ui)
             implementation(libs.compose.components.resources)

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/Icons.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/Icons.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.DefaultFillType
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+internal object Icons {
+    object Filled
+
+    object AutoMirrored {
+        object Filled
+    }
+
+    val Default = Filled
+}
+
+internal inline fun materialIcon(
+    name: String,
+    autoMirror: Boolean = false,
+    block: ImageVector.Builder.() -> ImageVector.Builder
+): ImageVector = ImageVector.Builder(
+    name = name,
+    defaultWidth = MaterialIconDimension.dp,
+    defaultHeight = MaterialIconDimension.dp,
+    viewportWidth = MaterialIconDimension,
+    viewportHeight = MaterialIconDimension,
+    autoMirror = autoMirror
+).block().build()
+
+internal inline fun ImageVector.Builder.materialPath(
+    fillAlpha: Float = 1f,
+    strokeAlpha: Float = 1f,
+    pathFillType: PathFillType = DefaultFillType,
+    pathBuilder: PathBuilder.() -> Unit
+): ImageVector.Builder =
+    path(
+        fill = SolidColor(Color.Black),
+        fillAlpha = fillAlpha,
+        stroke = null,
+        strokeAlpha = strokeAlpha,
+        strokeLineWidth = 1f,
+        strokeLineCap = StrokeCap.Butt,
+        strokeLineJoin = StrokeJoin.Bevel,
+        strokeLineMiter = 1f,
+        pathFillType = pathFillType,
+        pathBuilder = pathBuilder
+    )
+
+@PublishedApi
+internal const val MaterialIconDimension: Float = 24f

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/automirrored/filled/ArrowBackIos.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/automirrored/filled/ArrowBackIos.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.automirrored.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.AutoMirrored.Filled.ArrowBackIos: ImageVector
+    get() {
+        if (_arrowBackIos != null) {
+            return _arrowBackIos!!
+        }
+        _arrowBackIos = materialIcon(name = "AutoMirrored.Filled.ArrowBackIos", autoMirror = true) {
+            materialPath {
+                moveTo(11.67f, 3.87f)
+                lineTo(9.9f, 2.1f)
+                lineTo(0.0f, 12.0f)
+                lineToRelative(9.9f, 9.9f)
+                lineToRelative(1.77f, -1.77f)
+                lineTo(3.54f, 12.0f)
+                close()
+            }
+        }
+        return _arrowBackIos!!
+    }
+
+private var _arrowBackIos: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/automirrored/filled/Article.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/automirrored/filled/Article.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.automirrored.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.AutoMirrored.Filled.Article: ImageVector
+    get() {
+        if (_article != null) {
+            return _article!!
+        }
+        _article = materialIcon(name = "AutoMirrored.Filled.Article", autoMirror = true) {
+            materialPath {
+                moveTo(19.0f, 3.0f)
+                lineTo(5.0f, 3.0f)
+                curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+                verticalLineToRelative(14.0f)
+                curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                horizontalLineToRelative(14.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                lineTo(21.0f, 5.0f)
+                curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
+                close()
+                moveTo(14.0f, 17.0f)
+                lineTo(7.0f, 17.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(7.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(17.0f, 13.0f)
+                lineTo(7.0f, 13.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(10.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(17.0f, 9.0f)
+                lineTo(7.0f, 9.0f)
+                lineTo(7.0f, 7.0f)
+                horizontalLineToRelative(10.0f)
+                verticalLineToRelative(2.0f)
+                close()
+            }
+        }
+        return _article!!
+    }
+
+private var _article: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/ArrowDropDown.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/ArrowDropDown.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.ArrowDropDown: ImageVector
+    get() {
+        if (_arrowDropDown != null) {
+            return _arrowDropDown!!
+        }
+        _arrowDropDown = materialIcon(name = "Filled.ArrowDropDown") {
+            materialPath {
+                moveTo(7.0f, 10.0f)
+                lineToRelative(5.0f, 5.0f)
+                lineToRelative(5.0f, -5.0f)
+                close()
+            }
+        }
+        return _arrowDropDown!!
+    }
+
+private var _arrowDropDown: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/ClearAll.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/ClearAll.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.ClearAll: ImageVector
+    get() {
+        if (_clearAll != null) {
+            return _clearAll!!
+        }
+        _clearAll = materialIcon(name = "Filled.ClearAll") {
+            materialPath {
+                moveTo(5.0f, 13.0f)
+                horizontalLineToRelative(14.0f)
+                verticalLineToRelative(-2.0f)
+                lineTo(5.0f, 11.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(3.0f, 17.0f)
+                horizontalLineToRelative(14.0f)
+                verticalLineToRelative(-2.0f)
+                lineTo(3.0f, 15.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(7.0f, 7.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(14.0f)
+                lineTo(21.0f, 7.0f)
+                lineTo(7.0f, 7.0f)
+                close()
+            }
+        }
+        return _clearAll!!
+    }
+
+private var _clearAll: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Close.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Close.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Close: ImageVector
+    get() {
+        if (_close != null) {
+            return _close!!
+        }
+        _close = materialIcon(name = "Filled.Close") {
+            materialPath {
+                moveTo(19.0f, 6.41f)
+                lineTo(17.59f, 5.0f)
+                lineTo(12.0f, 10.59f)
+                lineTo(6.41f, 5.0f)
+                lineTo(5.0f, 6.41f)
+                lineTo(10.59f, 12.0f)
+                lineTo(5.0f, 17.59f)
+                lineTo(6.41f, 19.0f)
+                lineTo(12.0f, 13.41f)
+                lineTo(17.59f, 19.0f)
+                lineTo(19.0f, 17.59f)
+                lineTo(13.41f, 12.0f)
+                close()
+            }
+        }
+        return _close!!
+    }
+
+private var _close: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/ContentCopy.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/ContentCopy.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.ContentCopy: ImageVector
+    get() {
+        if (_contentCopy != null) {
+            return _contentCopy!!
+        }
+        _contentCopy = materialIcon(name = "Filled.ContentCopy") {
+            materialPath {
+                moveTo(16.0f, 1.0f)
+                lineTo(4.0f, 1.0f)
+                curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+                verticalLineToRelative(14.0f)
+                horizontalLineToRelative(2.0f)
+                lineTo(4.0f, 3.0f)
+                horizontalLineToRelative(12.0f)
+                lineTo(16.0f, 1.0f)
+                close()
+                moveTo(19.0f, 5.0f)
+                lineTo(8.0f, 5.0f)
+                curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+                verticalLineToRelative(14.0f)
+                curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                horizontalLineToRelative(11.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                lineTo(21.0f, 7.0f)
+                curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
+                close()
+                moveTo(19.0f, 21.0f)
+                lineTo(8.0f, 21.0f)
+                lineTo(8.0f, 7.0f)
+                horizontalLineToRelative(11.0f)
+                verticalLineToRelative(14.0f)
+                close()
+            }
+        }
+        return _contentCopy!!
+    }
+
+private var _contentCopy: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Delete.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Delete.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Delete: ImageVector
+    get() {
+        if (_delete != null) {
+            return _delete!!
+        }
+        _delete = materialIcon(name = "Filled.Delete") {
+            materialPath {
+                moveTo(6.0f, 19.0f)
+                curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                horizontalLineToRelative(8.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                verticalLineTo(7.0f)
+                horizontalLineTo(6.0f)
+                verticalLineToRelative(12.0f)
+                close()
+                moveTo(19.0f, 4.0f)
+                horizontalLineToRelative(-3.5f)
+                lineToRelative(-1.0f, -1.0f)
+                horizontalLineToRelative(-5.0f)
+                lineToRelative(-1.0f, 1.0f)
+                horizontalLineTo(5.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(14.0f)
+                verticalLineTo(4.0f)
+                close()
+            }
+        }
+        return _delete!!
+    }
+
+private var _delete: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/DisabledByDefault.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/DisabledByDefault.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.DisabledByDefault: ImageVector
+    get() {
+        if (_disabledByDefault != null) {
+            return _disabledByDefault!!
+        }
+        _disabledByDefault = materialIcon(name = "Filled.DisabledByDefault") {
+            materialPath {
+                moveTo(3.0f, 3.0f)
+                verticalLineToRelative(18.0f)
+                horizontalLineToRelative(18.0f)
+                verticalLineTo(3.0f)
+                horizontalLineTo(3.0f)
+                close()
+                moveTo(17.0f, 15.59f)
+                lineTo(15.59f, 17.0f)
+                lineTo(12.0f, 13.41f)
+                lineTo(8.41f, 17.0f)
+                lineTo(7.0f, 15.59f)
+                lineTo(10.59f, 12.0f)
+                lineTo(7.0f, 8.41f)
+                lineTo(8.41f, 7.0f)
+                lineTo(12.0f, 10.59f)
+                lineTo(15.59f, 7.0f)
+                lineTo(17.0f, 8.41f)
+                lineTo(13.41f, 12.0f)
+                lineTo(17.0f, 15.59f)
+                close()
+            }
+        }
+        return _disabledByDefault!!
+    }
+
+private var _disabledByDefault: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Downloading.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Downloading.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Downloading: ImageVector
+    get() {
+        if (_downloading != null) {
+            return _downloading!!
+        }
+        _downloading = materialIcon(name = "Filled.Downloading") {
+            materialPath {
+                moveTo(18.32f, 4.26f)
+                curveTo(16.84f, 3.05f, 15.01f, 2.25f, 13.0f, 2.05f)
+                verticalLineToRelative(2.02f)
+                curveToRelative(1.46f, 0.18f, 2.79f, 0.76f, 3.9f, 1.62f)
+                lineTo(18.32f, 4.26f)
+                close()
+                moveTo(19.93f, 11.0f)
+                horizontalLineToRelative(2.02f)
+                curveToRelative(-0.2f, -2.01f, -1.0f, -3.84f, -2.21f, -5.32f)
+                lineTo(18.31f, 7.1f)
+                curveTo(19.17f, 8.21f, 19.75f, 9.54f, 19.93f, 11.0f)
+                close()
+                moveTo(18.31f, 16.9f)
+                lineToRelative(1.43f, 1.43f)
+                curveToRelative(1.21f, -1.48f, 2.01f, -3.32f, 2.21f, -5.32f)
+                horizontalLineToRelative(-2.02f)
+                curveTo(19.75f, 14.46f, 19.17f, 15.79f, 18.31f, 16.9f)
+                close()
+                moveTo(13.0f, 19.93f)
+                verticalLineToRelative(2.02f)
+                curveToRelative(2.01f, -0.2f, 3.84f, -1.0f, 5.32f, -2.21f)
+                lineToRelative(-1.43f, -1.43f)
+                curveTo(15.79f, 19.17f, 14.46f, 19.75f, 13.0f, 19.93f)
+                close()
+                moveTo(13.0f, 12.0f)
+                verticalLineTo(7.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(5.0f)
+                horizontalLineTo(7.0f)
+                lineToRelative(5.0f, 5.0f)
+                lineToRelative(5.0f, -5.0f)
+                horizontalLineTo(13.0f)
+                close()
+                moveTo(11.0f, 19.93f)
+                verticalLineToRelative(2.02f)
+                curveToRelative(-5.05f, -0.5f, -9.0f, -4.76f, -9.0f, -9.95f)
+                reflectiveCurveToRelative(3.95f, -9.45f, 9.0f, -9.95f)
+                verticalLineToRelative(2.02f)
+                curveTo(7.05f, 4.56f, 4.0f, 7.92f, 4.0f, 12.0f)
+                reflectiveCurveTo(7.05f, 19.44f, 11.0f, 19.93f)
+                close()
+            }
+        }
+        return _downloading!!
+    }
+
+private var _downloading: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/FileDownload.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/FileDownload.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.FileDownload: ImageVector
+    get() {
+        if (_fileDownload != null) {
+            return _fileDownload!!
+        }
+        _fileDownload = materialIcon(name = "Filled.FileDownload") {
+            materialPath {
+                moveTo(19.0f, 9.0f)
+                horizontalLineToRelative(-4.0f)
+                verticalLineTo(3.0f)
+                horizontalLineTo(9.0f)
+                verticalLineToRelative(6.0f)
+                horizontalLineTo(5.0f)
+                lineToRelative(7.0f, 7.0f)
+                lineToRelative(7.0f, -7.0f)
+                close()
+                moveTo(5.0f, 18.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(14.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineTo(5.0f)
+                close()
+            }
+        }
+        return _fileDownload!!
+    }
+
+private var _fileDownload: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/HourglassTop.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/HourglassTop.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.HourglassTop: ImageVector
+    get() {
+        if (_hourglassTop != null) {
+            return _hourglassTop!!
+        }
+        _hourglassTop = materialIcon(name = "Filled.HourglassTop") {
+            materialPath {
+                moveTo(6.0f, 2.0f)
+                lineToRelative(0.01f, 6.0f)
+                lineTo(10.0f, 12.0f)
+                lineToRelative(-3.99f, 4.01f)
+                lineTo(6.0f, 22.0f)
+                horizontalLineToRelative(12.0f)
+                verticalLineToRelative(-6.0f)
+                lineToRelative(-4.0f, -4.0f)
+                lineToRelative(4.0f, -3.99f)
+                verticalLineTo(2.0f)
+                horizontalLineTo(6.0f)
+                close()
+                moveTo(16.0f, 16.5f)
+                verticalLineTo(20.0f)
+                horizontalLineTo(8.0f)
+                verticalLineToRelative(-3.5f)
+                lineToRelative(4.0f, -4.0f)
+                lineTo(16.0f, 16.5f)
+                close()
+            }
+        }
+        return _hourglassTop!!
+    }
+
+private var _hourglassTop: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/KeyboardArrowDown.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/KeyboardArrowDown.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.KeyboardArrowDown: ImageVector
+    get() {
+        if (_keyboardArrowDown != null) {
+            return _keyboardArrowDown!!
+        }
+        _keyboardArrowDown = materialIcon(name = "Filled.KeyboardArrowDown") {
+            materialPath {
+                moveTo(7.41f, 8.59f)
+                lineTo(12.0f, 13.17f)
+                lineToRelative(4.59f, -4.58f)
+                lineTo(18.0f, 10.0f)
+                lineToRelative(-6.0f, 6.0f)
+                lineToRelative(-6.0f, -6.0f)
+                lineToRelative(1.41f, -1.41f)
+                close()
+            }
+        }
+        return _keyboardArrowDown!!
+    }
+
+private var _keyboardArrowDown: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Language.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Language.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Language: ImageVector
+    get() {
+        if (_language != null) {
+            return _language!!
+        }
+        _language = materialIcon(name = "Filled.Language") {
+            materialPath {
+                moveTo(11.99f, 2.0f)
+                curveTo(6.47f, 2.0f, 2.0f, 6.48f, 2.0f, 12.0f)
+                reflectiveCurveToRelative(4.47f, 10.0f, 9.99f, 10.0f)
+                curveTo(17.52f, 22.0f, 22.0f, 17.52f, 22.0f, 12.0f)
+                reflectiveCurveTo(17.52f, 2.0f, 11.99f, 2.0f)
+                close()
+                moveTo(18.92f, 8.0f)
+                horizontalLineToRelative(-2.95f)
+                curveToRelative(-0.32f, -1.25f, -0.78f, -2.45f, -1.38f, -3.56f)
+                curveToRelative(1.84f, 0.63f, 3.37f, 1.91f, 4.33f, 3.56f)
+                close()
+                moveTo(12.0f, 4.04f)
+                curveToRelative(0.83f, 1.2f, 1.48f, 2.53f, 1.91f, 3.96f)
+                horizontalLineToRelative(-3.82f)
+                curveToRelative(0.43f, -1.43f, 1.08f, -2.76f, 1.91f, -3.96f)
+                close()
+                moveTo(4.26f, 14.0f)
+                curveTo(4.1f, 13.36f, 4.0f, 12.69f, 4.0f, 12.0f)
+                reflectiveCurveToRelative(0.1f, -1.36f, 0.26f, -2.0f)
+                horizontalLineToRelative(3.38f)
+                curveToRelative(-0.08f, 0.66f, -0.14f, 1.32f, -0.14f, 2.0f)
+                curveToRelative(0.0f, 0.68f, 0.06f, 1.34f, 0.14f, 2.0f)
+                lineTo(4.26f, 14.0f)
+                close()
+                moveTo(5.08f, 16.0f)
+                horizontalLineToRelative(2.95f)
+                curveToRelative(0.32f, 1.25f, 0.78f, 2.45f, 1.38f, 3.56f)
+                curveToRelative(-1.84f, -0.63f, -3.37f, -1.9f, -4.33f, -3.56f)
+                close()
+                moveTo(8.03f, 8.0f)
+                lineTo(5.08f, 8.0f)
+                curveToRelative(0.96f, -1.66f, 2.49f, -2.93f, 4.33f, -3.56f)
+                curveTo(8.81f, 5.55f, 8.35f, 6.75f, 8.03f, 8.0f)
+                close()
+                moveTo(12.0f, 19.96f)
+                curveToRelative(-0.83f, -1.2f, -1.48f, -2.53f, -1.91f, -3.96f)
+                horizontalLineToRelative(3.82f)
+                curveToRelative(-0.43f, 1.43f, -1.08f, 2.76f, -1.91f, 3.96f)
+                close()
+                moveTo(14.34f, 14.0f)
+                lineTo(9.66f, 14.0f)
+                curveToRelative(-0.09f, -0.66f, -0.16f, -1.32f, -0.16f, -2.0f)
+                curveToRelative(0.0f, -0.68f, 0.07f, -1.35f, 0.16f, -2.0f)
+                horizontalLineToRelative(4.68f)
+                curveToRelative(0.09f, 0.65f, 0.16f, 1.32f, 0.16f, 2.0f)
+                curveToRelative(0.0f, 0.68f, -0.07f, 1.34f, -0.16f, 2.0f)
+                close()
+                moveTo(14.59f, 19.56f)
+                curveToRelative(0.6f, -1.11f, 1.06f, -2.31f, 1.38f, -3.56f)
+                horizontalLineToRelative(2.95f)
+                curveToRelative(-0.96f, 1.65f, -2.49f, 2.93f, -4.33f, 3.56f)
+                close()
+                moveTo(16.36f, 14.0f)
+                curveToRelative(0.08f, -0.66f, 0.14f, -1.32f, 0.14f, -2.0f)
+                curveToRelative(0.0f, -0.68f, -0.06f, -1.34f, -0.14f, -2.0f)
+                horizontalLineToRelative(3.38f)
+                curveToRelative(0.16f, 0.64f, 0.26f, 1.31f, 0.26f, 2.0f)
+                reflectiveCurveToRelative(-0.1f, 1.36f, -0.26f, 2.0f)
+                horizontalLineToRelative(-3.38f)
+                close()
+            }
+        }
+        return _language!!
+    }
+
+private var _language: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Laptop.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Laptop.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Laptop: ImageVector
+    get() {
+        if (_laptop != null) {
+            return _laptop!!
+        }
+        _laptop = materialIcon(name = "Filled.Laptop") {
+            materialPath {
+                moveTo(20.0f, 18.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                verticalLineTo(6.0f)
+                curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
+                horizontalLineTo(4.0f)
+                curveTo(2.9f, 4.0f, 2.0f, 4.9f, 2.0f, 6.0f)
+                verticalLineToRelative(10.0f)
+                curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                horizontalLineTo(0.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(24.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineTo(20.0f)
+                close()
+                moveTo(4.0f, 6.0f)
+                horizontalLineToRelative(16.0f)
+                verticalLineToRelative(10.0f)
+                horizontalLineTo(4.0f)
+                verticalLineTo(6.0f)
+                close()
+            }
+        }
+        return _laptop!!
+    }
+
+private var _laptop: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Link.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Link.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Link: ImageVector
+    get() {
+        if (_link != null) {
+            return _link!!
+        }
+        _link = materialIcon(name = "Filled.Link") {
+            materialPath {
+                moveTo(3.9f, 12.0f)
+                curveToRelative(0.0f, -1.71f, 1.39f, -3.1f, 3.1f, -3.1f)
+                horizontalLineToRelative(4.0f)
+                lineTo(11.0f, 7.0f)
+                lineTo(7.0f, 7.0f)
+                curveToRelative(-2.76f, 0.0f, -5.0f, 2.24f, -5.0f, 5.0f)
+                reflectiveCurveToRelative(2.24f, 5.0f, 5.0f, 5.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(-1.9f)
+                lineTo(7.0f, 15.1f)
+                curveToRelative(-1.71f, 0.0f, -3.1f, -1.39f, -3.1f, -3.1f)
+                close()
+                moveTo(8.0f, 13.0f)
+                horizontalLineToRelative(8.0f)
+                verticalLineToRelative(-2.0f)
+                lineTo(8.0f, 11.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(17.0f, 7.0f)
+                horizontalLineToRelative(-4.0f)
+                verticalLineToRelative(1.9f)
+                horizontalLineToRelative(4.0f)
+                curveToRelative(1.71f, 0.0f, 3.1f, 1.39f, 3.1f, 3.1f)
+                reflectiveCurveToRelative(-1.39f, 3.1f, -3.1f, 3.1f)
+                horizontalLineToRelative(-4.0f)
+                lineTo(13.0f, 17.0f)
+                horizontalLineToRelative(4.0f)
+                curveToRelative(2.76f, 0.0f, 5.0f, -2.24f, 5.0f, -5.0f)
+                reflectiveCurveToRelative(-2.24f, -5.0f, -5.0f, -5.0f)
+                close()
+            }
+        }
+        return _link!!
+    }
+
+private var _link: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Lock.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Lock.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Lock: ImageVector
+    get() {
+        if (_lock != null) {
+            return _lock!!
+        }
+        _lock = materialIcon(name = "Filled.Lock") {
+            materialPath {
+                moveTo(18.0f, 8.0f)
+                horizontalLineToRelative(-1.0f)
+                lineTo(17.0f, 6.0f)
+                curveToRelative(0.0f, -2.76f, -2.24f, -5.0f, -5.0f, -5.0f)
+                reflectiveCurveTo(7.0f, 3.24f, 7.0f, 6.0f)
+                verticalLineToRelative(2.0f)
+                lineTo(6.0f, 8.0f)
+                curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+                verticalLineToRelative(10.0f)
+                curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                horizontalLineToRelative(12.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                lineTo(20.0f, 10.0f)
+                curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
+                close()
+                moveTo(12.0f, 17.0f)
+                curveToRelative(-1.1f, 0.0f, -2.0f, -0.9f, -2.0f, -2.0f)
+                reflectiveCurveToRelative(0.9f, -2.0f, 2.0f, -2.0f)
+                reflectiveCurveToRelative(2.0f, 0.9f, 2.0f, 2.0f)
+                reflectiveCurveToRelative(-0.9f, 2.0f, -2.0f, 2.0f)
+                close()
+                moveTo(15.1f, 8.0f)
+                lineTo(8.9f, 8.0f)
+                lineTo(8.9f, 6.0f)
+                curveToRelative(0.0f, -1.71f, 1.39f, -3.1f, 3.1f, -3.1f)
+                curveToRelative(1.71f, 0.0f, 3.1f, 1.39f, 3.1f, 3.1f)
+                verticalLineToRelative(2.0f)
+                close()
+            }
+        }
+        return _lock!!
+    }
+
+private var _lock: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/LockOpen.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/LockOpen.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.LockOpen: ImageVector
+    get() {
+        if (_lockOpen != null) {
+            return _lockOpen!!
+        }
+        _lockOpen = materialIcon(name = "Filled.LockOpen") {
+            materialPath {
+                moveTo(12.0f, 17.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                reflectiveCurveToRelative(-0.9f, -2.0f, -2.0f, -2.0f)
+                reflectiveCurveToRelative(-2.0f, 0.9f, -2.0f, 2.0f)
+                reflectiveCurveToRelative(0.9f, 2.0f, 2.0f, 2.0f)
+                close()
+                moveTo(18.0f, 8.0f)
+                horizontalLineToRelative(-1.0f)
+                lineTo(17.0f, 6.0f)
+                curveToRelative(0.0f, -2.76f, -2.24f, -5.0f, -5.0f, -5.0f)
+                reflectiveCurveTo(7.0f, 3.24f, 7.0f, 6.0f)
+                horizontalLineToRelative(1.9f)
+                curveToRelative(0.0f, -1.71f, 1.39f, -3.1f, 3.1f, -3.1f)
+                curveToRelative(1.71f, 0.0f, 3.1f, 1.39f, 3.1f, 3.1f)
+                verticalLineToRelative(2.0f)
+                lineTo(6.0f, 8.0f)
+                curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+                verticalLineToRelative(10.0f)
+                curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                horizontalLineToRelative(12.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                lineTo(20.0f, 10.0f)
+                curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
+                close()
+                moveTo(18.0f, 20.0f)
+                lineTo(6.0f, 20.0f)
+                lineTo(6.0f, 10.0f)
+                horizontalLineToRelative(12.0f)
+                verticalLineToRelative(10.0f)
+                close()
+            }
+        }
+        return _lockOpen!!
+    }
+
+private var _lockOpen: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/RestartAlt.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/RestartAlt.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.RestartAlt: ImageVector
+    get() {
+        if (_restartAlt != null) {
+            return _restartAlt!!
+        }
+        _restartAlt = materialIcon(name = "Filled.RestartAlt") {
+            materialPath {
+                moveTo(12.0f, 5.0f)
+                verticalLineTo(2.0f)
+                lineTo(8.0f, 6.0f)
+                lineToRelative(4.0f, 4.0f)
+                verticalLineTo(7.0f)
+                curveToRelative(3.31f, 0.0f, 6.0f, 2.69f, 6.0f, 6.0f)
+                curveToRelative(0.0f, 2.97f, -2.17f, 5.43f, -5.0f, 5.91f)
+                verticalLineToRelative(2.02f)
+                curveToRelative(3.95f, -0.49f, 7.0f, -3.85f, 7.0f, -7.93f)
+                curveTo(20.0f, 8.58f, 16.42f, 5.0f, 12.0f, 5.0f)
+                close()
+            }
+            materialPath {
+                moveTo(6.0f, 13.0f)
+                curveToRelative(0.0f, -1.65f, 0.67f, -3.15f, 1.76f, -4.24f)
+                lineTo(6.34f, 7.34f)
+                curveTo(4.9f, 8.79f, 4.0f, 10.79f, 4.0f, 13.0f)
+                curveToRelative(0.0f, 4.08f, 3.05f, 7.44f, 7.0f, 7.93f)
+                verticalLineToRelative(-2.02f)
+                curveTo(8.17f, 18.43f, 6.0f, 15.97f, 6.0f, 13.0f)
+                close()
+            }
+        }
+        return _restartAlt!!
+    }
+
+private var _restartAlt: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Search.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Search.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Search: ImageVector
+    get() {
+        if (_search != null) {
+            return _search!!
+        }
+        _search = materialIcon(name = "Filled.Search") {
+            materialPath {
+                moveTo(15.5f, 14.0f)
+                horizontalLineToRelative(-0.79f)
+                lineToRelative(-0.28f, -0.27f)
+                curveTo(15.41f, 12.59f, 16.0f, 11.11f, 16.0f, 9.5f)
+                curveTo(16.0f, 5.91f, 13.09f, 3.0f, 9.5f, 3.0f)
+                reflectiveCurveTo(3.0f, 5.91f, 3.0f, 9.5f)
+                reflectiveCurveTo(5.91f, 16.0f, 9.5f, 16.0f)
+                curveToRelative(1.61f, 0.0f, 3.09f, -0.59f, 4.23f, -1.57f)
+                lineToRelative(0.27f, 0.28f)
+                verticalLineToRelative(0.79f)
+                lineToRelative(5.0f, 4.99f)
+                lineTo(20.49f, 19.0f)
+                lineToRelative(-4.99f, -5.0f)
+                close()
+                moveTo(9.5f, 14.0f)
+                curveTo(7.01f, 14.0f, 5.0f, 11.99f, 5.0f, 9.5f)
+                reflectiveCurveTo(7.01f, 5.0f, 9.5f, 5.0f)
+                reflectiveCurveTo(14.0f, 7.01f, 14.0f, 9.5f)
+                reflectiveCurveTo(11.99f, 14.0f, 9.5f, 14.0f)
+                close()
+            }
+        }
+        return _search!!
+    }
+
+private var _search: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/SearchOff.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/SearchOff.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.SearchOff: ImageVector
+    get() {
+        if (_searchOff != null) {
+            return _searchOff!!
+        }
+        _searchOff = materialIcon(name = "Filled.SearchOff") {
+            materialPath {
+                moveTo(15.5f, 14.0f)
+                horizontalLineToRelative(-0.79f)
+                lineToRelative(-0.28f, -0.27f)
+                curveTo(15.41f, 12.59f, 16.0f, 11.11f, 16.0f, 9.5f)
+                curveTo(16.0f, 5.91f, 13.09f, 3.0f, 9.5f, 3.0f)
+                curveTo(6.08f, 3.0f, 3.28f, 5.64f, 3.03f, 9.0f)
+                horizontalLineToRelative(2.02f)
+                curveTo(5.3f, 6.75f, 7.18f, 5.0f, 9.5f, 5.0f)
+                curveTo(11.99f, 5.0f, 14.0f, 7.01f, 14.0f, 9.5f)
+                reflectiveCurveTo(11.99f, 14.0f, 9.5f, 14.0f)
+                curveToRelative(-0.17f, 0.0f, -0.33f, -0.03f, -0.5f, -0.05f)
+                verticalLineToRelative(2.02f)
+                curveTo(9.17f, 15.99f, 9.33f, 16.0f, 9.5f, 16.0f)
+                curveToRelative(1.61f, 0.0f, 3.09f, -0.59f, 4.23f, -1.57f)
+                lineTo(14.0f, 14.71f)
+                verticalLineToRelative(0.79f)
+                lineToRelative(5.0f, 4.99f)
+                lineTo(20.49f, 19.0f)
+                lineTo(15.5f, 14.0f)
+                close()
+            }
+            materialPath {
+                moveTo(6.47f, 10.82f)
+                lineToRelative(-2.47f, 2.47f)
+                lineToRelative(-2.47f, -2.47f)
+                lineToRelative(-0.71f, 0.71f)
+                lineToRelative(2.47f, 2.47f)
+                lineToRelative(-2.47f, 2.47f)
+                lineToRelative(0.71f, 0.71f)
+                lineToRelative(2.47f, -2.47f)
+                lineToRelative(2.47f, 2.47f)
+                lineToRelative(0.71f, -0.71f)
+                lineToRelative(-2.47f, -2.47f)
+                lineToRelative(2.47f, -2.47f)
+                close()
+            }
+        }
+        return _searchOff!!
+    }
+
+private var _searchOff: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Share.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Share.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Share: ImageVector
+    get() {
+        if (_share != null) {
+            return _share!!
+        }
+        _share = materialIcon(name = "Filled.Share") {
+            materialPath {
+                moveTo(18.0f, 16.08f)
+                curveToRelative(-0.76f, 0.0f, -1.44f, 0.3f, -1.96f, 0.77f)
+                lineTo(8.91f, 12.7f)
+                curveToRelative(0.05f, -0.23f, 0.09f, -0.46f, 0.09f, -0.7f)
+                reflectiveCurveToRelative(-0.04f, -0.47f, -0.09f, -0.7f)
+                lineToRelative(7.05f, -4.11f)
+                curveToRelative(0.54f, 0.5f, 1.25f, 0.81f, 2.04f, 0.81f)
+                curveToRelative(1.66f, 0.0f, 3.0f, -1.34f, 3.0f, -3.0f)
+                reflectiveCurveToRelative(-1.34f, -3.0f, -3.0f, -3.0f)
+                reflectiveCurveToRelative(-3.0f, 1.34f, -3.0f, 3.0f)
+                curveToRelative(0.0f, 0.24f, 0.04f, 0.47f, 0.09f, 0.7f)
+                lineTo(8.04f, 9.81f)
+                curveTo(7.5f, 9.31f, 6.79f, 9.0f, 6.0f, 9.0f)
+                curveToRelative(-1.66f, 0.0f, -3.0f, 1.34f, -3.0f, 3.0f)
+                reflectiveCurveToRelative(1.34f, 3.0f, 3.0f, 3.0f)
+                curveToRelative(0.79f, 0.0f, 1.5f, -0.31f, 2.04f, -0.81f)
+                lineToRelative(7.12f, 4.16f)
+                curveToRelative(-0.05f, 0.21f, -0.08f, 0.43f, -0.08f, 0.65f)
+                curveToRelative(0.0f, 1.61f, 1.31f, 2.92f, 2.92f, 2.92f)
+                curveToRelative(1.61f, 0.0f, 2.92f, -1.31f, 2.92f, -2.92f)
+                reflectiveCurveToRelative(-1.31f, -2.92f, -2.92f, -2.92f)
+                close()
+            }
+        }
+        return _share!!
+    }
+
+private var _share: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Tag.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Tag.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Tag: ImageVector
+    get() {
+        if (_tag != null) {
+            return _tag!!
+        }
+        _tag = materialIcon(name = "Filled.Tag") {
+            materialPath {
+                moveTo(20.0f, 10.0f)
+                lineTo(20.0f, 8.0f)
+                horizontalLineToRelative(-4.0f)
+                lineTo(16.0f, 4.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(4.0f)
+                horizontalLineToRelative(-4.0f)
+                lineTo(10.0f, 4.0f)
+                lineTo(8.0f, 4.0f)
+                verticalLineToRelative(4.0f)
+                lineTo(4.0f, 8.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(4.0f)
+                lineTo(4.0f, 14.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(4.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(-4.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(4.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(-4.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(-4.0f)
+                verticalLineToRelative(-4.0f)
+                horizontalLineToRelative(4.0f)
+                close()
+                moveTo(14.0f, 14.0f)
+                horizontalLineToRelative(-4.0f)
+                verticalLineToRelative(-4.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(4.0f)
+                close()
+            }
+        }
+        return _tag!!
+    }
+
+private var _tag: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Timer.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Timer.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Timer: ImageVector
+    get() {
+        if (_timer != null) {
+            return _timer!!
+        }
+        _timer = materialIcon(name = "Filled.Timer") {
+            materialPath {
+                moveTo(9.0f, 1.0f)
+                horizontalLineToRelative(6.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(-6.0f)
+                close()
+            }
+            materialPath {
+                moveTo(19.03f, 7.39f)
+                lineToRelative(1.42f, -1.42f)
+                curveToRelative(-0.43f, -0.51f, -0.9f, -0.99f, -1.41f, -1.41f)
+                lineToRelative(-1.42f, 1.42f)
+                curveTo(16.07f, 4.74f, 14.12f, 4.0f, 12.0f, 4.0f)
+                curveToRelative(-4.97f, 0.0f, -9.0f, 4.03f, -9.0f, 9.0f)
+                curveToRelative(0.0f, 4.97f, 4.02f, 9.0f, 9.0f, 9.0f)
+                reflectiveCurveToRelative(9.0f, -4.03f, 9.0f, -9.0f)
+                curveTo(21.0f, 10.88f, 20.26f, 8.93f, 19.03f, 7.39f)
+                close()
+                moveTo(13.0f, 14.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineTo(8.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineTo(14.0f)
+                close()
+            }
+        }
+        return _timer!!
+    }
+
+private var _timer: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/TouchApp.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/TouchApp.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.TouchApp: ImageVector
+    get() {
+        if (_touchApp != null) {
+            return _touchApp!!
+        }
+        _touchApp = materialIcon(name = "Filled.TouchApp") {
+            materialPath {
+                moveTo(9.0f, 11.24f)
+                verticalLineTo(7.5f)
+                curveTo(9.0f, 6.12f, 10.12f, 5.0f, 11.5f, 5.0f)
+                reflectiveCurveTo(14.0f, 6.12f, 14.0f, 7.5f)
+                verticalLineToRelative(3.74f)
+                curveToRelative(1.21f, -0.81f, 2.0f, -2.18f, 2.0f, -3.74f)
+                curveTo(16.0f, 5.01f, 13.99f, 3.0f, 11.5f, 3.0f)
+                reflectiveCurveTo(7.0f, 5.01f, 7.0f, 7.5f)
+                curveTo(7.0f, 9.06f, 7.79f, 10.43f, 9.0f, 11.24f)
+                close()
+                moveTo(18.84f, 15.87f)
+                lineToRelative(-4.54f, -2.26f)
+                curveToRelative(-0.17f, -0.07f, -0.35f, -0.11f, -0.54f, -0.11f)
+                horizontalLineTo(13.0f)
+                verticalLineToRelative(-6.0f)
+                curveTo(13.0f, 6.67f, 12.33f, 6.0f, 11.5f, 6.0f)
+                reflectiveCurveTo(10.0f, 6.67f, 10.0f, 7.5f)
+                verticalLineToRelative(10.74f)
+                curveToRelative(-3.6f, -0.76f, -3.54f, -0.75f, -3.67f, -0.75f)
+                curveToRelative(-0.31f, 0.0f, -0.59f, 0.13f, -0.79f, 0.33f)
+                lineToRelative(-0.79f, 0.8f)
+                lineToRelative(4.94f, 4.94f)
+                curveTo(9.96f, 23.83f, 10.34f, 24.0f, 10.75f, 24.0f)
+                horizontalLineToRelative(6.79f)
+                curveToRelative(0.75f, 0.0f, 1.33f, -0.55f, 1.44f, -1.28f)
+                lineToRelative(0.75f, -5.27f)
+                curveToRelative(0.01f, -0.07f, 0.02f, -0.14f, 0.02f, -0.2f)
+                curveTo(19.75f, 16.63f, 19.37f, 16.09f, 18.84f, 15.87f)
+                close()
+            }
+        }
+        return _touchApp!!
+    }
+
+private var _touchApp: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Tune.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Tune.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Tune: ImageVector
+    get() {
+        if (_tune != null) {
+            return _tune!!
+        }
+        _tune = materialIcon(name = "Filled.Tune") {
+            materialPath {
+                moveTo(3.0f, 17.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(6.0f)
+                verticalLineToRelative(-2.0f)
+                lineTo(3.0f, 17.0f)
+                close()
+                moveTo(3.0f, 5.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(10.0f)
+                lineTo(13.0f, 5.0f)
+                lineTo(3.0f, 5.0f)
+                close()
+                moveTo(13.0f, 21.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(8.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(-8.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(6.0f)
+                horizontalLineToRelative(2.0f)
+                close()
+                moveTo(7.0f, 9.0f)
+                verticalLineToRelative(2.0f)
+                lineTo(3.0f, 11.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(4.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(2.0f)
+                lineTo(9.0f, 9.0f)
+                lineTo(7.0f, 9.0f)
+                close()
+                moveTo(21.0f, 13.0f)
+                verticalLineToRelative(-2.0f)
+                lineTo(11.0f, 11.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(10.0f)
+                close()
+                moveTo(15.0f, 9.0f)
+                horizontalLineToRelative(2.0f)
+                lineTo(17.0f, 7.0f)
+                horizontalLineToRelative(4.0f)
+                lineTo(21.0f, 5.0f)
+                horizontalLineToRelative(-4.0f)
+                lineTo(17.0f, 3.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(6.0f)
+                close()
+            }
+        }
+        return _tune!!
+    }
+
+private var _tune: ImageVector? = null

--- a/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Warning.kt
+++ b/core/library/src/commonMain/kotlin/androidx/compose/material/icons/filled/Warning.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Icons.Filled.Warning: ImageVector
+    get() {
+        if (_warning != null) {
+            return _warning!!
+        }
+        _warning = materialIcon(name = "Filled.Warning") {
+            materialPath {
+                moveTo(1.0f, 21.0f)
+                horizontalLineToRelative(22.0f)
+                lineTo(12.0f, 2.0f)
+                lineTo(1.0f, 21.0f)
+                close()
+                moveTo(13.0f, 18.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(13.0f, 14.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(-4.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(4.0f)
+                close()
+            }
+        }
+        return _warning!!
+    }
+
+private var _warning: ImageVector? = null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ ktor = "3.5.0"
 okhttp = "5.4.0"
 http4k = "6.53.0.0"
 material3AdaptiveNavigationSuite = "1.9.0"
-materialIconsExtended = "1.7.3"
 material3 = "1.11.0-alpha07"
 slf4j = "2.0.18"
 sqldelight = "2.3.2"
@@ -55,7 +54,6 @@ compose-adaptive-layout = { module = "org.jetbrains.compose.material3.adaptive:a
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
-compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-material3-adaptive-navigation-suite = { module = "org.jetbrains.compose.material3:material3-adaptive-navigation-suite", version.ref = "material3AdaptiveNavigationSuite" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
Remove the `material-icons-extended` dependency and copy only the Material icon sources currently used by the core library.

`material-icons-extended` is a very large dependency, so depending on it just for a small set of icons is not ideal.